### PR TITLE
Learning rate cut, model debug, and fix

### DIFF
--- a/model.py
+++ b/model.py
@@ -50,8 +50,12 @@ with tf.variable_scope("RNN"):
             initializer=tf.random_normal_initializer()
         )
     with tf.variable_scope("softmax"):
-        softmax_w = tf.get_variable("weight", shape=[HIDDEN_SIZE, VOCABULARY_SIZE])
-        softmax_b = tf.get_variable("bias", shape=[VOCABULARY_SIZE])
+        softmax_w = tf.get_variable(
+            "weight",
+            shape=[HIDDEN_SIZE, VOCABULARY_SIZE],
+            initializer=tf.random_normal_initializer()
+        )
+        softmax_b = tf.get_variable("bias", shape=[VOCABULARY_SIZE], initializer=tf.constant_initializer(0.1))
     for time_step in range(SEQ_LEN - 1):
         if time_step > 0:
             tf.get_variable_scope().reuse_variables()
@@ -97,7 +101,8 @@ for epoch_idx in range(NUM_EPOCH):
             feed_dict={
                 input_placeholder: batch_input,
                 target_placeholder: batch_output,
-                learning_rate_placeholder: learning_rate}
+                learning_rate_placeholder: learning_rate,
+            }
         )
     if best_loss * 0.999 < fetch_loss:
         print("Current loss ", fetch_loss, "was not significantly better than best loss of", best_loss)

--- a/model.py
+++ b/model.py
@@ -93,6 +93,7 @@ epochs_without_improvement = 0
 
 for epoch_idx in range(NUM_EPOCH):
     if epochs_without_improvement >= LEARNING_RATE_CUT_EPOCH:
+        epochs_without_improvement = 0
         learning_rate /= 10
         print("Cutting learning rate to", learning_rate)
     if learning_rate <= LEARNING_RATE_MIN:

--- a/model.py
+++ b/model.py
@@ -66,8 +66,10 @@ with tf.variable_scope("RNN"):
         (cell_output, state) = rnn_cell(digit_embeddings, state)
         logits = tf.matmul(cell_output, softmax_w) + softmax_b
         outputs.append(logits)
+        states.append(state)
 
     output = tf.reshape(tf.concat(1, outputs), [-1, VOCABULARY_SIZE])
+    hidden_states = tf.reshape(tf.concat(1, states), [-1, SEQ_LEN - 1, HIDDEN_SIZE])
 
     labels_batched = tf.reshape(target_placeholder, [-1])
     target_weights = tf.ones([BATCH_SIZE * (SEQ_LEN - 1)])
@@ -98,8 +100,8 @@ for epoch_idx in range(NUM_EPOCH):
         break
     for batch_idx in range(NUM_BATCH):
         batch_input, batch_output = make_batch(random_data[batch_idx])
-        fetch_output, fetch_labels, fetch_softmax, fetch_loss, fetch_grad_vars, _ = sess.run(
-            [output, labels_batched, softmax_outputs, loss, grads_and_vars, train_step],
+        fetch_output, fetch_labels, fetch_softmax, fetch_states, fetch_loss, fetch_grad_vars, _ = sess.run(
+            [output, labels_batched, softmax_outputs, hidden_states, loss, grads_and_vars, train_step],
             feed_dict={
                 input_placeholder: batch_input,
                 target_placeholder: batch_output,

--- a/model.py
+++ b/model.py
@@ -7,7 +7,7 @@ from tensorflow.python.ops.rnn_cell import BasicRNNCell
 SEQ_LEN = 10
 BATCH_SIZE = 32
 VOCABULARY_SIZE = 10
-HIDDEN_SIZE = 8
+HIDDEN_SIZE = 2
 NUM_BATCH = 1024
 LEARNING_RATE_START = 1e-2
 LEARNING_RATE_MIN = 1e-6
@@ -17,8 +17,12 @@ random_data = np.zeros([NUM_BATCH, BATCH_SIZE, SEQ_LEN], dtype=np.int32)
 
 for batch_idx in range(NUM_BATCH):
     for example_idx in range(BATCH_SIZE):
+        repeated_digit = random.randint(0, 3)
         for seq_idx in range(SEQ_LEN):
-            label = random.randint(0, 3)
+            if seq_idx % 3 == 0:
+                label = repeated_digit
+            else:
+                label = 0
             random_data[batch_idx, example_idx, seq_idx] = label
 
 
@@ -68,7 +72,7 @@ with tf.variable_scope("RNN"):
     labels_batched = tf.reshape(target_placeholder, [-1])
     target_weights = tf.ones([BATCH_SIZE * (SEQ_LEN - 1)])
 
-    softmax_outputs = tf.nn.softmax(output)
+    softmax_outputs = tf.reshape(tf.nn.softmax(output), [-1, SEQ_LEN - 1, VOCABULARY_SIZE])
     loss = tf.nn.seq2seq.sequence_loss(
         [output],
         [labels_batched],

--- a/model.py
+++ b/model.py
@@ -9,7 +9,9 @@ BATCH_SIZE = 10
 TOTAL_SEQ = 100000
 HIDDEN_SIZE = 10
 NUM_BATCH = TOTAL_SEQ // (SEQ_LEN * BATCH_SIZE)
-LEARNING_RATE_START = 3e-4
+LEARNING_RATE_START = 1e-1
+LEARNING_RATE_MIN = 1e-6
+LEARNING_RATE_CUT_EPOCH = 10
 NUM_EPOCH = 100
 random_digits = [random.randint(0, 3) for i in range(TOTAL_SEQ)]
 random_inputs = np.zeros([NUM_BATCH, BATCH_SIZE, SEQ_LEN, 10])
@@ -53,10 +55,14 @@ with tf.variable_scope("RNN"):
     output = tf.reshape(tf.concat(1, outputs), [-1, HIDDEN_SIZE])
     cell_states = tf.reshape(tf.concat(1, states), [-1, HIDDEN_SIZE])
 
+    labels_batched = tf.reshape(target_placeholder, [-1])
+    target_weights = tf.ones([BATCH_SIZE * (SEQ_LEN - 1)])
+
+    softmax_outputs = tf.nn.softmax(output)
     loss = tf.nn.seq2seq.sequence_loss(
         [output],
-        [tf.reshape(target_placeholder, [-1])],
-        [tf.ones([BATCH_SIZE * (SEQ_LEN - 1)])])
+        [labels_batched],
+        [target_weights])
 
 optimizer = tf.train.AdamOptimizer(learning_rate_placeholder)
 train_step = optimizer.minimize(loss)
@@ -65,18 +71,37 @@ sess = tf.Session()
 sess.run(tf.global_variables_initializer())
 learning_rate = LEARNING_RATE_START
 
+best_loss = np.inf
+epochs_without_improvement = 0
+
 for epoch_idx in range(NUM_EPOCH):
-    fetch_loss = 0
-    # if epoch_idx % 10 == 0:
-    #     learning_rate /= 2
+    if epochs_without_improvement >= LEARNING_RATE_CUT_EPOCH:
+        learning_rate /= 10
+        print("Cutting learning rate to", learning_rate)
+    if learning_rate <= LEARNING_RATE_MIN:
+        print("Ending training since model is not learning")
+        break
     for batch_idx in range(NUM_BATCH):
         batch_input, batch_output = make_batch(random_inputs[batch_idx], random_outputs[batch_idx])
-        fetch_loss, _ = sess.run(
-            [loss, train_step],
+        fetch_output, fetch_labels, fetch_label_weights, fetch_softmax, fetch_loss, _ = sess.run(
+            [output, labels_batched, target_weights, softmax_outputs, loss, train_step],
             feed_dict={
                 input_placeholder: batch_input,
                 target_placeholder: batch_output,
                 learning_rate_placeholder: learning_rate}
         )
+    if best_loss * 0.9999 < fetch_loss:
+        print("Current loss ", fetch_loss, "was not significantly better than best loss of", best_loss)
+        epochs_without_improvement += 1
+        print("Now at", epochs_without_improvement, "epoch(s) without improvement out of", LEARNING_RATE_CUT_EPOCH)
+    else:
+        best_loss = fetch_loss
+        epochs_without_improvement = 0
+        print("Got new best loss of: ", best_loss)
 
-    print("Epoch:", epoch_idx, "Loss:", fetch_loss, "LR:", learning_rate)
+    if not fetch_loss:
+        raise Exception("You set either NUM_EPOCH or NUM_BATCH to 0")
+    else:
+        print("Epoch:", epoch_idx, "Loss:", fetch_loss, "LR:", learning_rate)
+
+print("Training completed - attained loss", best_loss)

--- a/model.py
+++ b/model.py
@@ -11,7 +11,7 @@ HIDDEN_SIZE = 10
 NUM_BATCH = TOTAL_SEQ // (SEQ_LEN * BATCH_SIZE)
 LEARNING_RATE_START = 1e-1
 LEARNING_RATE_MIN = 1e-6
-LEARNING_RATE_CUT_EPOCH = 10
+LEARNING_RATE_CUT_EPOCH = 3
 NUM_EPOCH = 100
 random_digits = [random.randint(0, 3) for i in range(TOTAL_SEQ)]
 random_inputs = np.zeros([NUM_BATCH, BATCH_SIZE, SEQ_LEN, 10])
@@ -24,7 +24,7 @@ for batch_idx in range(NUM_BATCH):
             random_inputs[batch_idx, example_idx, seq_idx, label] = 1
             random_outputs[batch_idx, example_idx, seq_idx] = label
 
-rnn_cell = BasicRNNCell(10, activation=tf.sigmoid)
+rnn_cell = BasicRNNCell(10)
 
 
 def make_batch(raw_batch_inputs, raw_batch_outputs):

--- a/model.py
+++ b/model.py
@@ -45,8 +45,8 @@ states = []
 
 with tf.variable_scope("RNN"):
     for time_step in range(SEQ_LEN - 1):
-        if time_step > 0:
-            tf.get_variable_scope().reuse_variables()
+        # if time_step > 0:
+        #     tf.get_variable_scope().reuse_variables()
 
         (cell_output, state) = rnn_cell(input_placeholder[:, time_step, :], state)
         states.append(state)
@@ -65,7 +65,8 @@ with tf.variable_scope("RNN"):
         [target_weights])
 
 optimizer = tf.train.AdamOptimizer(learning_rate_placeholder)
-train_step = optimizer.minimize(loss)
+grads_and_vars = optimizer.compute_gradients(loss)
+train_step = optimizer.apply_gradients(grads_and_vars)
 
 sess = tf.Session()
 sess.run(tf.global_variables_initializer())
@@ -83,8 +84,8 @@ for epoch_idx in range(NUM_EPOCH):
         break
     for batch_idx in range(NUM_BATCH):
         batch_input, batch_output = make_batch(random_inputs[batch_idx], random_outputs[batch_idx])
-        fetch_output, fetch_labels, fetch_label_weights, fetch_softmax, fetch_loss, _ = sess.run(
-            [output, labels_batched, target_weights, softmax_outputs, loss, train_step],
+        fetch_output, fetch_labels, fetch_label_weights, fetch_softmax, fetch_loss, fetch_grad_vars, _ = sess.run(
+            [output, labels_batched, target_weights, softmax_outputs, loss, grads_and_vars, train_step],
             feed_dict={
                 input_placeholder: batch_input,
                 target_placeholder: batch_output,

--- a/model.py
+++ b/model.py
@@ -4,26 +4,22 @@ import numpy as np
 import tensorflow as tf
 from tensorflow.python.ops.rnn_cell import BasicRNNCell
 
-SEQ_LEN = 5
-BATCH_SIZE = 10
-TOTAL_SEQ = 100000
+SEQ_LEN = 10
+BATCH_SIZE = 32
 VOCABULARY_SIZE = 10
-HIDDEN_SIZE = 32
-NUM_BATCH = TOTAL_SEQ // (SEQ_LEN * BATCH_SIZE)
+HIDDEN_SIZE = 8
+NUM_BATCH = 1024
 LEARNING_RATE_START = 1e-2
 LEARNING_RATE_MIN = 1e-6
 LEARNING_RATE_CUT_EPOCH = 3
 NUM_EPOCH = 100
-random_digits = [random.randint(0, 3) for i in range(TOTAL_SEQ)]
 random_data = np.zeros([NUM_BATCH, BATCH_SIZE, SEQ_LEN], dtype=np.int32)
 
 for batch_idx in range(NUM_BATCH):
     for example_idx in range(BATCH_SIZE):
         for seq_idx in range(SEQ_LEN):
-            label = random_digits.pop()
+            label = random.randint(0, 3)
             random_data[batch_idx, example_idx, seq_idx] = label
-
-rnn_cell = BasicRNNCell(HIDDEN_SIZE)
 
 
 def make_batch(random_batch):
@@ -32,6 +28,8 @@ def make_batch(random_batch):
 
     return xs, ys
 
+
+rnn_cell = BasicRNNCell(HIDDEN_SIZE)
 
 input_placeholder = tf.placeholder(dtype=tf.int32, shape=[None, SEQ_LEN - 1], name="input")
 


### PR DESCRIPTION
- Add logic for cutting learning rate by 1/10th after a fixed number of stagnant epochs
- Break apart computation into tensors to fetch during debug to examine training behavior
- Add embedding layer
- Add output weights + bias (`softmax_w` and `softmax_b`) - this fixes the issue with the model's inability to output sufficiently high scores for the correct classes
- Try decreasing RNN hidden state capacity, while increasing batch and sequence length